### PR TITLE
Support reading from streams with multiple shards

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,5 @@
+ruby:
+  enabled: true
+  config_file: .rubocop.yml
+fail_on_violations: true
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,54 @@
+ClassAndModuleChildren:
+  Include:
+    - lib/**/*.rb
+Documentation:
+  Enabled: false
+EmptyLinesAroundBlockBody:
+  Enabled: false
+EmptyLinesAroundClassBody:
+  Enabled: false
+EmptyLinesAroundModuleBody:
+  Enabled: false
+ExtraSpacing:
+  Enabled: false
+LineLength:
+  # Default is that lines should be 80, but that's somewhat noisy. We want a softer limit.
+  Description: Limit lines to 120 characters.
+  Max: 120
+  Exclude:
+    - config/routes.rb
+Lint/EndAlignment:
+  # The value `keyword` means that `end` should be aligned with the matching
+  # keyword (if, while, etc.).
+  # The value `variable` means that in assignments, `end` should be aligned
+  # with the start of the variable on the left hand side of `=`. In all other
+  # situations, `end` should still be aligned with the keyword.
+  AlignWith: variable
+  SupportedStyles:
+    - keyword
+    - variable
+Lint/UnusedMethodArgument:
+  Exclude:
+    - app/interactors/**/*.rb
+Lint/UselessAccessModifier:
+  Enabled: false
+SingleSpaceBeforeFirstArg:
+  Enabled: false
+SpaceInsideBrackets:
+  Enabled: false
+StringLiterals:
+  EnforcedStyle: single_quotes
+  Enabled: true
+Style/Blocks:
+  Enabled: false
+Style/CollectionMethods:
+  PreferredMethods:
+    find: 'detect'
+Style/BracesAroundHashParameters:
+  EnforcedStyle: context_dependent
+  SupportedStyles:
+    - braces
+    - no_braces
+    - context_dependent
+Style/IndentHash:
+  Enabled: false

--- a/lib/shard_reader.rb
+++ b/lib/shard_reader.rb
@@ -45,6 +45,7 @@ class ShardReader
             @logger.debug "Getting records for #{shard_iterator}"
             resp = @client.get_records(shard_iterator: shard_iterator,
                                        limit: @batch_size)
+            @logger.info "This batch is #{resp.millis_behind_latest} behind the latest"
 
             resp.records.each do |record|
               process_record(record, resp, &block)

--- a/lib/shard_reader.rb
+++ b/lib/shard_reader.rb
@@ -1,0 +1,85 @@
+class ShardReader
+
+  def initialize(stream_name:,
+                 tracker_prefix:,
+                 shard_id:,
+                 batch_size:,
+                 logger:,
+                 client:)
+    @stream_name = stream_name
+    @tracker_prefix = tracker_prefix
+    @shard_id = shard_id
+    @batch_size = batch_size
+    @logger = logger
+    @client = client
+    @stop_processing = false
+
+    key_prefix = [ @stream_name,
+                   @tracker_prefix,
+                   shard_id ].compact.join('-')
+    @tracker = SequenceNumberTracker.new(key_prefix: key_prefix)
+  end
+
+  def run(&block)
+    @thread = Thread.new do
+      loop do
+        break if @stop_processing
+        begin
+          iterator_opts = { stream_name: @stream_name,
+                            shard_id: @shard_id }
+          if seq = @tracker.last_sequence_number
+            iterator_opts[:shard_iterator_type] = 'AFTER_SEQUENCE_NUMBER'
+            iterator_opts[:starting_sequence_number] = seq
+          else
+            iterator_opts[:shard_iterator_type] = 'TRIM_HORIZON'
+          end
+          @logger.debug "Getting shard iterator for #{@stream_name} / #{@shard_id} / #{seq}"
+
+          resp = @client.get_shard_iterator(iterator_opts)
+          shard_iterator = resp.shard_iterator
+
+          # Iterate!
+          loop do
+            break if @stop_processing
+            sleep 1
+            @logger.debug "Getting records for #{shard_iterator}"
+            resp = @client.get_records(shard_iterator: shard_iterator,
+                                       limit: @batch_size)
+
+            resp.records.each do |record|
+              process_record(record, resp, &block)
+            end
+            shard_iterator = resp.next_shard_iterator
+          end
+
+        rescue Aws::Kinesis::Errors::ExpiredIteratorException
+          @logger.debug "Iterator expired! Fetching a new one."
+        end
+      end
+    end
+  end
+
+  def join
+    @thread.join
+  end
+
+  def stop_processing!
+    @stop_processing = true
+  end
+
+  private
+
+  def process_record(record, resp, &block)
+    instrument_opts = {
+      stream_name: @stream_name,
+      prefix: @prefix,
+      shard_id: @shard_id,
+      ms_behind: resp.millis_behind_latest
+    }
+    ActiveSupport::Notifications.instrument('stream_reader.process_record',
+                                            instrument_opts) do
+      AvroParser.new(record.data).each_with_schema_name(&block)
+      @tracker.last_sequence_number = record.sequence_number
+    end
+  end
+end

--- a/lib/stream_reader.rb
+++ b/lib/stream_reader.rb
@@ -1,4 +1,5 @@
 require 'stream_helper'
+require 'shard_reader'
 
 class StreamReader
   class << self
@@ -10,83 +11,45 @@ class StreamReader
   # Assume only one shard for now
   DEFAULT_BATCH_SIZE = 100
 
-  def initialize(stream_name:, prefix: '')
+  def initialize(stream_name:, prefix: '', client: Aws::Kinesis::Client.new)
     @stream_name = stream_name
     @prefix      = prefix
     @logger      = StreamReader.logger
-    trap('SIGTERM') { @stop_processing = true; puts 'Exiting...' }
+    @client      = client
+    trap('SIGTERM') do
+      puts 'Caught SIGTERM, exiting...'
+      stop!
+    end
   end
-
-  attr_reader :stop_processing
 
   def run!(batch_size: DEFAULT_BATCH_SIZE, &block)
     LibratoReporter.run! if send_to_librato?
 
-    threads = []
+    @runners = []
     each_shard do |shard_id|
-      threads << spawn_runner_for_shard(shard_id, &block)
+      @runners << spawn_reader_for_shard(shard_id, batch_size, &block)
     end
-    threads.map(&:join)
+  end
+
+  def stop!
+    @runners.map(&:stop_processing!)
+    @runners.map(&:join)
   end
 
   private
 
-  def spawn_runner_for_shard(shard_id, &block)
-    Thread.new do
-      key_prefix = [ @stream_name, @prefix, shard_id ].compact.join('-')
-      tracker = SequenceNumberTracker.new(key_prefix: key_prefix)
-
-      loop do
-        break if stop_processing
-        begin
-          iterator_opts = { stream_name: @stream_name, shard_id: shard_id }
-          if seq = tracker.last_sequence_number
-            iterator_opts[:shard_iterator_type] = 'AFTER_SEQUENCE_NUMBER'
-            iterator_opts[:starting_sequence_number] = seq
-          else
-            iterator_opts[:shard_iterator_type] = 'TRIM_HORIZON'
-          end
-          @logger.debug "Getting shard iterator for #{@stream_name} / #{shard_id} / #{seq}"
-          resp = client.get_shard_iterator(iterator_opts)
-          shard_iterator = resp.shard_iterator
-
-          # Iterate!
-          loop do
-            break if stop_processing
-            sleep 1
-            @logger.debug "Getting records for #{shard_iterator}"
-            resp = client.get_records({
-              shard_iterator: shard_iterator,
-              limit: batch_size,
-            })
-
-            resp.records.each do |record|
-              ActiveSupport::Notifications.instrument('stream_reader.process_record',
-                                                      stream_name: @stream_name,
-                                                      prefix: @prefix,
-                                                      shard_id: shard_id,
-                                                      ms_behind: resp.millis_behind_latest) do
-                AvroParser.new(record.data).each_with_schema_name(&block)
-                @tracker.last_sequence_number = record.sequence_number
-              end
-            end
-
-            shard_iterator = resp.next_shard_iterator
-          end
-
-        rescue Aws::Kinesis::Errors::ExpiredIteratorException
-          @logger.debug "Iterator expired! Fetching a new one."
-        end
-      end
-    end
-  end
-
-  def client
-    @client ||= Aws::Kinesis::Client.new
+  def spawn_reader_for_shard(shard_id, batch_size, &block)
+    ShardReader.new(stream_name: @stream_name,
+                    tracker_prefix: @prefix,
+                    shard_id: shard_id,
+                    batch_size: batch_size,
+                    logger: @logger,
+                    client: @client).tap { |sr| sr.run(&block) }
   end
 
   def each_shard
-    client.describe_stream(stream_name: @stream_name).stream_description.shards.each do |shard|
+    resp = @client.describe_stream(stream_name: @stream_name)
+    resp.stream_description.shards.each do |shard|
       yield shard.shard_id
     end
   end

--- a/lib/stream_reader.rb
+++ b/lib/stream_reader.rb
@@ -13,7 +13,6 @@ class StreamReader
   def initialize(stream_name:, prefix: '')
     @stream_name = stream_name
     @prefix      = prefix
-    @tracker     = SequenceNumberTracker.new(key_prefix: [ stream_name, prefix ].compact.join('-'))
     @logger      = StreamReader.logger
     trap('SIGTERM') { @stop_processing = true; puts 'Exiting...' }
   end
@@ -23,62 +22,73 @@ class StreamReader
   def run!(batch_size: DEFAULT_BATCH_SIZE, &block)
     LibratoReporter.run! if send_to_librato?
 
-    # Locate a shard id to iterate through - we only have one for now
-    loop do
-      break if stop_processing
-      begin
-        iterator_opts = { stream_name: @stream_name, shard_id: shard_id }
-        if seq = @tracker.last_sequence_number
-          iterator_opts[:shard_iterator_type] = 'AFTER_SEQUENCE_NUMBER'
-          iterator_opts[:starting_sequence_number] = seq
-        else
-          iterator_opts[:shard_iterator_type] = 'TRIM_HORIZON'
-        end
-        @logger.debug "Getting shard iterator for #{@stream_name} / #{seq}"
-        resp = client.get_shard_iterator(iterator_opts)
-        shard_iterator = resp.shard_iterator
-
-        # Iterate!
-        loop do
-          break if stop_processing
-          sleep 1
-          @logger.debug "Getting records for #{shard_iterator}"
-          resp = client.get_records({
-            shard_iterator: shard_iterator,
-            limit: batch_size,
-          })
-
-          resp.records.each do |record|
-            ActiveSupport::Notifications.instrument('stream_reader.process_record',
-                                                    stream_name: @stream_name,
-                                                    prefix: @prefix,
-                                                    shard_id: shard_id,
-                                                    ms_behind: resp.millis_behind_latest) do
-              AvroParser.new(record.data).each_with_schema_name(&block)
-              @tracker.last_sequence_number = record.sequence_number
-            end
-          end
-
-          shard_iterator = resp.next_shard_iterator
-        end
-
-      rescue Aws::Kinesis::Errors::ExpiredIteratorException
-        @logger.debug "Iterator expired! Fetching a new one."
-      end
+    threads = []
+    each_shard do |shard_id|
+      threads << spawn_runner_for_shard(shard_id, &block)
     end
+    threads.map(&:join)
   end
 
   private
+
+  def spawn_runner_for_shard(shard_id, &block)
+    Thread.new do
+      key_prefix = [ @stream_name, @prefix, shard_id ].compact.join('-')
+      tracker = SequenceNumberTracker.new(key_prefix: key_prefix)
+
+      loop do
+        break if stop_processing
+        begin
+          iterator_opts = { stream_name: @stream_name, shard_id: shard_id }
+          if seq = tracker.last_sequence_number
+            iterator_opts[:shard_iterator_type] = 'AFTER_SEQUENCE_NUMBER'
+            iterator_opts[:starting_sequence_number] = seq
+          else
+            iterator_opts[:shard_iterator_type] = 'TRIM_HORIZON'
+          end
+          @logger.debug "Getting shard iterator for #{@stream_name} / #{shard_id} / #{seq}"
+          resp = client.get_shard_iterator(iterator_opts)
+          shard_iterator = resp.shard_iterator
+
+          # Iterate!
+          loop do
+            break if stop_processing
+            sleep 1
+            @logger.debug "Getting records for #{shard_iterator}"
+            resp = client.get_records({
+              shard_iterator: shard_iterator,
+              limit: batch_size,
+            })
+
+            resp.records.each do |record|
+              ActiveSupport::Notifications.instrument('stream_reader.process_record',
+                                                      stream_name: @stream_name,
+                                                      prefix: @prefix,
+                                                      shard_id: shard_id,
+                                                      ms_behind: resp.millis_behind_latest) do
+                AvroParser.new(record.data).each_with_schema_name(&block)
+                @tracker.last_sequence_number = record.sequence_number
+              end
+            end
+
+            shard_iterator = resp.next_shard_iterator
+          end
+
+        rescue Aws::Kinesis::Errors::ExpiredIteratorException
+          @logger.debug "Iterator expired! Fetching a new one."
+        end
+      end
+    end
+  end
 
   def client
     @client ||= Aws::Kinesis::Client.new
   end
 
-  def shard_id
-    @shard_id ||= begin
-                    resp = client.describe_stream(stream_name: @stream_name, limit: 1)
-                    resp.stream_description.shards[0].shard_id
-                  end
+  def each_shard
+    client.describe_stream(stream_name: @stream_name).stream_description.shards.each do |shard|
+      yield shard.shard_id
+    end
   end
 
   def send_to_librato?

--- a/lib/stream_reader/version.rb
+++ b/lib/stream_reader/version.rb
@@ -1,3 +1,3 @@
 class StreamReader
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/spec/shard_reader_spec.rb
+++ b/spec/shard_reader_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require_relative '../lib/shard_reader'
+require 'logger'
+
+describe ShardReader do
+  describe 'executing a runner' do
+    let(:reader) do
+      ShardReader.new(stream_name: 'test_stream',
+                      tracker_prefix: 'test-tracker',
+                      shard_id: 'abc123',
+                      batch_size: 1,
+                      logger: StreamReader.logger,
+                      client: Aws::Kinesis::Client.new)
+    end
+
+    it 'runs a block for each record returned' do
+      stub_processor = double
+      expect(stub_processor).to receive(:process).at_least(:once)
+      reader.run { |record| stub_processor.process }
+      sleep 3
+      reader.stop_processing!
+      reader.join
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,60 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'pry'
 require 'fakeredis/rspec'
 
+require 'aws-sdk-core'
+
+avro_stub = File.read(File.expand_path('../support/user_was_created.avro', __FILE__))
+
+Aws.config[:stub_responses] = true
+Aws.config[:kinesis] = {
+  stub_responses: {
+    describe_stream: {
+      stream_description: {
+        stream_name: 'test_stream',
+        stream_arn: '',
+        has_more_shards: false,
+        retention_period_hours: 24,
+        enhanced_monitoring: [],
+        stream_status: 'ACTIVE',
+        shards: [
+          {
+            shard_id: 'abc123',
+            hash_key_range: {
+              starting_hash_key: '',
+              ending_hash_key: ''
+            },
+            sequence_number_range: {
+              starting_sequence_number: '1',
+              ending_sequence_number: nil
+            }
+          },
+          {
+            shard_id: 'def456',
+            hash_key_range: {
+              starting_hash_key: '',
+              ending_hash_key: ''
+            },
+            sequence_number_range: {
+              starting_sequence_number: '1',
+              ending_sequence_number: nil
+            }
+          }
+        ]
+      }
+    },
+    get_shard_iterator: {
+      shard_iterator: 'ghi789'
+    },
+    get_records: {
+      records: [
+        { data: avro_stub, partition_key: '', sequence_number: '' }
+      ],
+      millis_behind_latest: 10,
+      next_shard_iterator: 'jkl012'
+    }
+  }
+}
+
 RSpec.configure do |config|
   config.color = true
 end

--- a/spec/stream_reader_spec.rb
+++ b/spec/stream_reader_spec.rb
@@ -6,4 +6,25 @@ describe StreamReader do
   it 'has a logger' do
     expect(described_class.logger).to be_a(Logger)
   end
+
+  describe 'spawning runner threads' do
+    let(:client) { Aws::Kinesis::Client.new }
+    let(:reader) { StreamReader.new(stream_name: 'test_stream', client: client) }
+
+    it 'spawns a ShardReader for each shard returned' do
+      allow_any_instance_of(ShardReader).to receive(:run).and_return(Thread.new { })
+      expect(ShardReader).to receive(:new).twice.and_call_original
+      reader.run! do
+        # No-op
+      end
+    end
+
+    it 'starts and stops gracefully' do
+      stub_processor = double
+      expect(stub_processor).to receive(:process).at_least(:once)
+      reader.run! { |record| stub_processor.process }
+      sleep 3
+      reader.stop!
+    end
+  end
 end


### PR DESCRIPTION
Previously we only supported a single shard, which worked for our needs initially. Now that we're putting a lot more traffic on Kinesis, we need the ability to have our readers work off of multiple shards.

This PR takes the approach of spawning a runner thread for each shard in a stream, and executing the block there. While it does require that users ensure that whatever they do inside their processing blocks is thread-safe (particularly as it relates to connection pools for AR, Redis, etc.), it seems like a more straightforward/performant solution to start with. We could look at a preforking worker model in the future if we wanted to go that route.

Bumps version to 0.2.0 as well.

TODOs:

- [x] README updates and caveats (at least in part about renaming the Tracker key before deploy and thread safety)
- [ ] Updates across our apps using this gem (plus a new version number)
- [x] Tests (https://stelligent.com/2016/04/14/using-stubs-for-the-aws-sdk-for-ruby-2/)