### PR TITLE
Fix prefix reporting for ActiveSupport::Notifications

### DIFF
--- a/lib/shard_reader.rb
+++ b/lib/shard_reader.rb
@@ -76,7 +76,7 @@ class ShardReader
   def process_record(record, resp, &block)
     instrument_opts = {
       stream_name: @stream_name,
-      prefix: @prefix,
+      prefix: @tracker_prefix,
       shard_id: @shard_id,
       ms_behind: resp.millis_behind_latest
     }


### PR DESCRIPTION
The variable name changed in the sharding refactor, so it’s getting lost when passed to AS::N subscribers now (including Librato).