### PR TITLE
Short-circuit Librato when config is not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 HEAD
 ------------------
 * Bugfix - Fix an issue where metric assignments on different threads were erroring when submitting to Librato (https://github.com/ello/kinesis-stream-reader/pull/18)
+* Bugfix - Don't attempt to fire up Librato when credentials are not specified
 
 0.3.0 (2017-05-05)
 ------------------

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Version 0.2.0 introduced a threading model for spawning multiple readers to serv
 - If your processing blocks are idempotent and fast, you can simply do nothing and let the processors re-process old data starting from the `TRIM_HORIZON`.
 - Otherwise, you can manually obtain the `shard_id` value from a `DescribeStream` call and move the value of the last processed sequence number to a new key in Redis. You'll need to stop your workers while doing this. This will avoid re-processing the same records multiple times.
 
+### Librato Telemetry
+If you specify the `LIBRATO_USER` and `LIBRATO_TOKEN` environment variables, shard processor stats will be periodically reported to Librato (with the metrics `stream_reader.process_record.duration` and `stream_reader.process_record.latency` and a custom source that identifies the prefix and shard id). It is highly recommended that you monitor at least the latency metric to ensure that your processors do not fall so far behind that data is [dropped from the stream](http://docs.aws.amazon.com/streams/latest/dev/kinesis-extended-retention.html) before it can be processed. If you monitor that metric, you should also have a "dead man's switch"-type metric that alerts if it stops reporting.
+
 ## Contributing
 Bug reports and pull requests are welcome on GitHub at https://github.com/ello/kinesis-stream-reader.
 

--- a/lib/stream_reader/librato_reporter.rb
+++ b/lib/stream_reader/librato_reporter.rb
@@ -4,6 +4,7 @@ require 'thread'
 module LibratoReporter
   class << self
     def run!
+      return unless config_present?
       @client = Librato::Metrics::Client.new
       @client.authenticate(ENV['LIBRATO_USER'],
                            ENV['LIBRATO_TOKEN'])
@@ -17,6 +18,13 @@ module LibratoReporter
     end
 
     private
+
+    def config_present?
+      !(ENV['LIBRATO_USER'].nil?) &&
+        !(ENV['LIBRATO_USER'].empty?) &&
+        !(ENV['LIBRATO_TOKEN'].nil?) &&
+        !(ENV['LIBRATO_TOKEN'].empty?)
+    end
 
     def add_listeners
       ActiveSupport::Notifications.subscribe('stream_reader.process_record') do |name, start, finish, id, payload|


### PR DESCRIPTION
Rails's `empty?` would be nice here but I don't want to rely on it since this may not always be used in a Rails context.